### PR TITLE
Don't use googles custom windows builder

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -191,7 +191,7 @@ jobs:
 
   build-dotnet-windows:
     name: Build .NET Windows
-    runs-on: windows-2022-64core
+    runs-on: windows-latest
     strategy:
       matrix:
         configuration: [
@@ -455,7 +455,7 @@ jobs:
 
   build-rust-windows:
     name: Build Rust Windows
-    runs-on: windows-2022-64core
+    runs-on: windows-latest
     steps:
     - uses: actions/checkout@v3
     - name: test


### PR DESCRIPTION
Google actions just hang forever if the runner doesn't exist in your environment