### PR TITLE
Filter union JSON Schema completion by discriminator

### DIFF
--- a/src/idl_gen_json_schema.cpp
+++ b/src/idl_gen_json_schema.cpp
@@ -259,8 +259,6 @@ static std::string GenDefaultValue(const Type &type) {
 }
 
 static std::string GenNullableType(const FieldDef &field) {
-  const std::string base_type = GenType(field.value.type);
-
   bool can_be_null = false;
 
   if (field.IsOptional()) {
@@ -268,6 +266,40 @@ static std::string GenNullableType(const FieldDef &field) {
   } else if (!field.IsRequired() && !IsScalar(field.value.type.base_type)) {
     can_be_null = true;
   }
+
+  // Union value fields: emit only a permissive JSON type and let the table's
+  // allOf/if-then block (keyed on <field>_type) supply the per-variant $ref.
+  // Emitting an anyOf of all variants here makes editors offer every variant's
+  // fields when completing an empty value object.
+  if (field.value.type.base_type == BASE_TYPE_UNION) {
+    // Constrain to the JSON types the members use: object for table/struct,
+    // string for string members, plus null when optional.
+    bool has_object = false;
+    bool has_string = false;
+    for (const auto &union_value : field.value.type.enum_def->Vals()) {
+      switch (union_value->union_type.base_type) {
+        case BASE_TYPE_STRUCT: has_object = true; break;  // table or struct
+        case BASE_TYPE_STRING: has_string = true; break;
+        default: break;  // BASE_TYPE_NONE
+      }
+    }
+    std::vector<std::string> json_types;
+    if (has_object) json_types.push_back("\"object\"");
+    if (has_string) json_types.push_back("\"string\"");
+    if (can_be_null) json_types.push_back("\"null\"");
+    // Union with only a NONE member.
+    if (json_types.empty()) return "\"type\" : \"null\"";
+    if (json_types.size() == 1) return "\"type\" : " + json_types.front();
+    std::string joined = "\"type\" : [";
+    for (size_t i = 0; i < json_types.size(); ++i) {
+      if (i != 0) joined.append(", ");
+      joined.append(json_types[i]);
+    }
+    joined.append("]");
+    return joined;
+  }
+
+  const std::string base_type = GenType(field.value.type);
 
   if (can_be_null) {
     return "\"anyOf\": [{ \"type\": \"null\" }, { " + base_type + " }]";

--- a/tests/monster_test.schema.json
+++ b/tests/monster_test.schema.json
@@ -231,7 +231,7 @@
                 "x-flatbuffers-attributes": {"id": "7"}
               },
         "test" : {
-                "anyOf": [{ "type": "null" }, { "anyOf": [{ "$ref" : "#/definitions/MyGame_Example_Monster" },{ "$ref" : "#/definitions/MyGame_Example_TestSimpleTableWithEnum" },{ "$ref" : "#/definitions/MyGame_Example2_Monster" }] }],
+                "type" : ["object", "null"],
                 "default": null,
                 "x-flatbuffers-attributes": {"id": "8"}
               },
@@ -396,7 +396,7 @@
                 "x-flatbuffers-attributes": {"id": "43"}
               },
         "any_unique" : {
-                "anyOf": [{ "type": "null" }, { "anyOf": [{ "$ref" : "#/definitions/MyGame_Example_Monster" },{ "$ref" : "#/definitions/MyGame_Example_TestSimpleTableWithEnum" },{ "$ref" : "#/definitions/MyGame_Example2_Monster" }] }],
+                "type" : ["object", "null"],
                 "default": null,
                 "x-flatbuffers-attributes": {"id": "44"}
               },
@@ -405,7 +405,7 @@
                 "x-flatbuffers-attributes": {"id": "45"}
               },
         "any_ambiguous" : {
-                "anyOf": [{ "type": "null" }, { "anyOf": [{ "$ref" : "#/definitions/MyGame_Example_Monster" },{ "$ref" : "#/definitions/MyGame_Example_Monster" },{ "$ref" : "#/definitions/MyGame_Example_Monster" }] }],
+                "type" : ["object", "null"],
                 "default": null,
                 "x-flatbuffers-attributes": {"id": "46"}
               },

--- a/tests/union_vector/union_vector.schema.json
+++ b/tests/union_vector/union_vector.schema.json
@@ -62,7 +62,7 @@
                 "type" : "string", "enum": ["NONE", "MuLan", "Rapunzel", "Belle", "BookFan", "Other", "Unused"]
               },
         "main_character" : {
-                "anyOf": [{ "type": "null" }, { "anyOf": [{ "$ref" : "#/definitions/Attacker" },{ "$ref" : "#/definitions/Rapunzel" },{ "$ref" : "#/definitions/BookReader" },{ "$ref" : "#/definitions/BookReader" },{ "type": "string" },{ "type": "string" }] }],
+                "type" : ["object", "string", "null"],
                 "default": null
               },
         "characters_type" : {


### PR DESCRIPTION
The --jsonschema generator emitted each union value field as an anyOf of every variant's $ref. The VS Code JSON language service merges that into autocompletion whenever the value is an empty object, so it offered the fields of all variants regardless of the <field>_type discriminator. The existing allOf/if/then block already supplies the correct per-variant schema for validation, but does not drive empty-object completion.

Emit only a permissive JSON type for the union value field (derived from its members' JSON shapes: object for table/struct, string for string members, plus null when optional) and let the if/then discriminator provide the concrete per-variant $ref. Completion now narrows to the selected variant; validation is unchanged.

Regenerated the affected committed schemas (monster_test, union_vector).