### PR TITLE
Fix __vector_as_array to pass byte length to ByteBuffer.ToArray

### DIFF
--- a/net/FlatBuffers/Table.cs
+++ b/net/FlatBuffers/Table.cs
@@ -150,7 +150,7 @@ namespace Google.FlatBuffers
 
             var pos = this.__vector(o);
             var len = this.__vector_len(o);
-            return bb.ToArray<T>(pos, len);
+            return bb.ToArray<T>(pos, len * ByteBuffer.SizeOf<T>());
         }
 
         // Initialize any Table-derived type to point to the union at the given offset.


### PR DESCRIPTION
ByteBuffer.ToArray<T>(int posInBytes, int lenInBytes) interprets its length argument as bytes, but Table.__vector_as_array<T> passed the vector's element count (__vector_len) directly. For any element type wider than one byte this read too few elements (len bytes instead of len elements), returning a truncated array.

Multiply by ByteBuffer.SizeOf<T>() to pass the byte length, matching upstream google/flatbuffers.
